### PR TITLE
Fix version in cargo.toml to make build pass after dependencies update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,20 @@ edition = "2018"
 crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
-lazy_static = "^1"
-serde = "^1"
-serde_derive = "^1"
-serde_json = "^1"
-wasm-bindgen-futures = "^0"
-yew = "^0"
-yew-router = "^0"
+lazy_static = "1"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+wasm-bindgen-futures = "0"
+yew = "0.17"
+yew-router = "0.14"
 
 [dependencies.wasm-bindgen]
-version = "^0"
+version = "0"
 features = [ "serde-serialize" ]
 
 [dependencies.web-sys]
-version = "^0"
+version = "0"
 features = [ "ScrollToOptions", "ScrollBehavior", "Window", "Request" ]
 
 


### PR DESCRIPTION
The project depends on some early version of yew so I updated the cargo.toml to use compatible version.